### PR TITLE
fix/auth : 카카오 로그인 null-safe 방어 코드 추가,프론트에서 scope 명시적으로 요청하도록

### DIFF
--- a/src/main/java/ssuchaehwa/it_project/domain/login/api/TestController.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/login/api/TestController.java
@@ -1,6 +1,7 @@
 package ssuchaehwa.it_project.domain.login.api;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,6 +17,9 @@ import ssuchaehwa.it_project.domain.user.repository.UserRepository;
 import ssuchaehwa.it_project.global.config.security.jwt.JwtUtil;
 import ssuchaehwa.it_project.global.config.security.auth.UserPrincipal;
 
+import java.util.Optional;
+
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class TestController {
@@ -40,15 +44,34 @@ public class TestController {
 
     @GetMapping("/login/oauth/kakao")
     public String kakaoCallback(@RequestParam String code, Model model) {
+        // 1. 카카오 토큰 및 사용자 정보 요청
         AuthResponseDto.KakaoToken kakaoToken = kakaoOAuthClient.requestToken(code);
         AuthResponseDto.KakaoUserInfo userInfo = kakaoOAuthClient.requestUserInfo(kakaoToken.getAccessToken());
 
+        // 2. Optional 기반 null-safe 파싱
+        Optional<AuthResponseDto.KakaoUserInfo.KakaoAccount> kakaoAccountOpt = Optional.ofNullable(userInfo.getKakaoAccount());
+
+        String nickname = kakaoAccountOpt
+                .map(AuthResponseDto.KakaoUserInfo.KakaoAccount::getProfile)
+                .map(AuthResponseDto.KakaoUserInfo.KakaoAccount.Profile::getNickname)
+                .orElse("게스트");
+
+        String profileImageUrl = kakaoAccountOpt
+                .map(AuthResponseDto.KakaoUserInfo.KakaoAccount::getProfile)
+                .map(AuthResponseDto.KakaoUserInfo.KakaoAccount.Profile::getProfileImageUrl)
+                .orElse(null);
+
+        // 3. 디버깅 로그로 확인
+        log.info("✅ [카카오 로그인 응답] id={}, nickname={}, profileImageUrl={}",
+                userInfo.getId(), nickname, profileImageUrl);
+
+        // 4. 기존 사용자 조회 또는 신규 저장
         User user = userRepository.findBySocialId(String.valueOf(userInfo.getId()))
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .socialId(String.valueOf(userInfo.getId()))
-                                .nickname(userInfo.getKakaoAccount().getProfile().getNickname())
-                                .profileImageUrl(userInfo.getKakaoAccount().getProfile().getProfileImageUrl())
+                                .nickname(nickname)
+                                .profileImageUrl(profileImageUrl)
                                 .level(1)
                                 .exp(0)
                                 .gold(0)
@@ -57,14 +80,17 @@ public class TestController {
                                 .build()
                 ));
 
+        // 5. JWT 발급
         String jwtAccessToken = jwtUtil.generateAccessToken(String.valueOf(user.getId()));
         String jwtRefreshToken = jwtUtil.generateRefreshToken(String.valueOf(user.getId()));
 
+        // 6. 모델에 전달
         model.addAttribute("authCode", code);
         model.addAttribute("kakaoAccessToken", kakaoToken.getAccessToken());
         model.addAttribute("kakaoRefreshToken", kakaoToken.getRefreshToken());
         model.addAttribute("accessToken", jwtAccessToken);
         model.addAttribute("refreshToken", jwtRefreshToken);
+
         return "kakaoCallback";
     }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/login/domain/KakaoOAuthClient.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/login/domain/KakaoOAuthClient.java
@@ -10,6 +10,8 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import ssuchaehwa.it_project.domain.login.dto.AuthResponseDto;
 
+import java.util.Optional;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -35,20 +37,26 @@ public class KakaoOAuthClient {
      * @return 카카오 토큰 응답 DTO
      */
     public AuthResponseDto.KakaoToken requestToken(String code) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", clientId);
-        body.add("redirect_uri", redirectUri);
-        body.add("code", code);
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", "authorization_code");
+            body.add("client_id", clientId);
+            body.add("redirect_uri", redirectUri);
+            body.add("code", code);
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
-        ResponseEntity<AuthResponseDto.KakaoToken> response =
-                restTemplate.postForEntity(tokenUri, request, AuthResponseDto.KakaoToken.class);
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+            ResponseEntity<AuthResponseDto.KakaoToken> response =
+                    restTemplate.postForEntity(tokenUri, request, AuthResponseDto.KakaoToken.class);
 
-        return response.getBody();
+            return Optional.ofNullable(response.getBody())
+                    .orElseThrow(() -> new RuntimeException("카카오 토큰 응답이 null입니다."));
+        } catch (Exception e) {
+            log.error("❌ 카카오 토큰 요청 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("카카오 토큰 요청 실패", e);
+        }
     }
 
     /**
@@ -57,15 +65,21 @@ public class KakaoOAuthClient {
      * @return 카카오 사용자 정보 응답 DTO
      */
     public AuthResponseDto.KakaoUserInfo requestUserInfo(String accessToken) {
-        log.info("🟡 requestUserInfo() - accessToken: {}", accessToken);
+        try {
+            log.info("🟡 requestUserInfo() - accessToken: {}", accessToken);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<AuthResponseDto.KakaoUserInfo> response =
-                restTemplate.exchange(userInfoUri, HttpMethod.GET, entity, AuthResponseDto.KakaoUserInfo.class);
+            ResponseEntity<AuthResponseDto.KakaoUserInfo> response =
+                    restTemplate.exchange(userInfoUri, HttpMethod.GET, entity, AuthResponseDto.KakaoUserInfo.class);
 
-        return response.getBody();
+            return Optional.ofNullable(response.getBody())
+                    .orElseThrow(() -> new RuntimeException("카카오 사용자 정보 응답이 null입니다."));
+        } catch (Exception e) {
+            log.error("❌ 카카오 사용자 정보 요청 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("카카오 사용자 정보 요청 실패", e);
+        }
     }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/login/dto/AuthResponseDto.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/login/dto/AuthResponseDto.java
@@ -1,9 +1,6 @@
 package ssuchaehwa.it_project.domain.login.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AuthResponseDto {
@@ -52,6 +49,7 @@ public class AuthResponseDto {
             private Profile profile;
 
             @Getter
+            @Setter
             @NoArgsConstructor
             @AllArgsConstructor
             public static class Profile {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -16,7 +16,8 @@
 
     function kakaoLogin() {
         Kakao.Auth.authorize({
-            redirectUri: [[${kakaoRedirectUri}]]
+            redirectUri: [[${kakaoRedirectUri}]],
+            scope: "profile_nickname, profile_image"
         });
     }
 </script>


### PR DESCRIPTION
## 📌 PR 개요
- 카카오 로그인 시 nickname, profile_image_url이 null로 들어오는 문제를 방지
- KakaoAccount, Profile 객체에 대한 null-safe 처리 적용
- 프론트엔드에서 명시적으로 scope 요청 추가 (profile_nickname, profile_image)
## 🔧 작업 내용
- KakaoOAuthClient에서 Optional 및 null 체크를 통해 안정적인 nickname/profileImage 파싱
- LoginService에서 최초 로그인 시에만 사용자 정보를 저장하도록 조건 처리
- Thymeleaf 테스트 페이지에서 scope를 명시적으로 요청하도록 JS 수정
- 테스트용 Controller에 디버깅용 로그 추가 (✅ [카카오 로그인 응답] ...)
## 📷 테스트
<img width="798" alt="image" src="https://github.com/user-attachments/assets/a0258dd7-7100-4cf1-bbbf-89ac1515b36d" />

## ❗️추가 내용

