### PR TITLE
feat: 개인 퀘스트 수정, 삭제 api 구현, 관련 dto 수정

### DIFF
--- a/src/main/java/ssuchaehwa/it_project/domain/quest/api/QuestRestController.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/api/QuestRestController.java
@@ -154,4 +154,35 @@ public class QuestRestController {
 
         return BaseResponse.onSuccess(SuccessStatus.INVITE_PARTY_STATUS_CHANGE, result);
     }
+
+    // 퀘스트 수정 API
+    @PutMapping(value = "/{questId}")
+    @Operation(summary = "퀘스트를 수정하는 API", description = "questId와 questUpdateRequest를 전달해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "QUEST_202", description = "OK, 퀘스트가 성공적으로 수정되었습니다.")
+    })
+    public BaseResponse<QuestResponseDTO.QuestUpdateResponse> updateQuest(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long questId,
+            @RequestBody @Valid QuestRequestDTO.QuestUpdateRequest questUpdateRequest
+    ) {
+        QuestResponseDTO.QuestUpdateResponse result = questService.updateQuest(questId, questUpdateRequest, principal.getId());
+
+        return BaseResponse.onSuccess(SuccessStatus.QUEST_UPDATED, result);
+    }
+
+    // 퀘스트 삭제 API
+    @DeleteMapping(value = "/{questId}")
+    @Operation(summary = "퀘스트를 삭제하는 API", description = "questId를 전달해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "QUEST_203", description = "OK, 퀘스트가 성공적으로 삭제되었습니다.")
+    })
+    public BaseResponse<QuestResponseDTO.QuestDeleteResponse> deleteQuest(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long questId
+    ) {
+        QuestResponseDTO.QuestDeleteResponse result = questService.deleteQuest(questId, principal.getId());
+
+        return BaseResponse.onSuccess(SuccessStatus.QUEST_DELETED, result);
+    }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/application/QuestService.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/application/QuestService.java
@@ -34,4 +34,10 @@ public interface QuestService {
 
     // 파티 수락 / 거절
     QuestResponseDTO.PartyInvitationResponse respondToInvitation(Long userId, QuestRequestDTO.PartyInvitationResponseRequest request);
+
+    // 퀘스트 수정
+    QuestResponseDTO.QuestUpdateResponse updateQuest(Long questId, QuestRequestDTO.QuestUpdateRequest request, Long userId);
+
+    // 퀘스트 삭제
+    QuestResponseDTO.QuestDeleteResponse deleteQuest(Long questId, Long userId);
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/converter/QuestConverter.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/converter/QuestConverter.java
@@ -77,6 +77,10 @@ public class QuestConverter {
                         )
                         .questType(quest.getQuestType())
                         .completionStatus(quest.getCompletionStatus())
+                        .startTime(quest.getStartTime())
+                        .endTime(quest.getEndTime())
+                        .startDate(quest.getStartDate())
+                        .dueDate(quest.getDueDate())
                         .build())
                 .toList();
     }
@@ -139,6 +143,23 @@ public class QuestConverter {
                 .partyId(party.getId())
                 .partyName(party.getTitle())
                 .invitationStatus(partyUser.getInvitationStatus())
+                .build();
+    }
+
+    // 퀘스트 수정 응답 변환
+    public static QuestResponseDTO.QuestUpdateResponse toQuestUpdateResponse(Quest quest) {
+        return QuestResponseDTO.QuestUpdateResponse.builder()
+                .questId(quest.getId())
+                .content(quest.getTitle())
+                .message("퀘스트가 성공적으로 수정되었습니다.")
+                .build();
+    }
+
+    // 퀘스트 삭제 응답 변환
+    public static QuestResponseDTO.QuestDeleteResponse toQuestDeleteResponse(Long questId) {
+        return QuestResponseDTO.QuestDeleteResponse.builder()
+                .questId(questId)
+                .message("퀘스트가 성공적으로 삭제되었습니다.")
                 .build();
     }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/domain/entity/Quest.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/domain/entity/Quest.java
@@ -67,4 +67,17 @@ public class Quest extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "quest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<HashtagQuest> hashtagQuests = new ArrayList<>();
+
+    // 퀘스트 수정 메서드
+    public void updateQuest(String content, int priority, QuestType questType,
+                            LocalTime startTime, LocalTime endTime,
+                            LocalDate startDate, LocalDate dueDate) {
+        this.title = content;
+        this.priority = priority;
+        this.questType = questType;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/domain/repository/HashtagQuestRepository.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/domain/repository/HashtagQuestRepository.java
@@ -2,6 +2,11 @@ package ssuchaehwa.it_project.domain.quest.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import ssuchaehwa.it_project.domain.quest.domain.entity.HashtagQuest;
+import ssuchaehwa.it_project.domain.quest.domain.entity.Quest;
+
+import java.util.List;
 
 public interface HashtagQuestRepository extends JpaRepository<HashtagQuest, Long> {
+    void deleteByQuest(Quest quest);
+    List<HashtagQuest> findByQuest(Quest quest);
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/domain/repository/HashtagRepository.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/domain/repository/HashtagRepository.java
@@ -4,8 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import ssuchaehwa.it_project.domain.quest.domain.entity.Hashtag;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
     List<Hashtag> findAllByNameIn(List<String> names);
+
+    Optional<Hashtag> findByName(String name);
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/dto/QuestRequestDTO.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/dto/QuestRequestDTO.java
@@ -87,4 +87,24 @@ public class QuestRequestDTO {
         private Long partyId;
         private InvitationStatus responseStatus;
     }
+
+    // 퀘스트 수정 요청 DTO
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class QuestUpdateRequest {
+
+        @Column(length = 100)
+        private String content;
+
+        private int priority;
+        private QuestType questType;
+        private List<String> hashtags;
+
+        private LocalTime startTime;
+        private LocalTime endTime;
+        private LocalDate startDate;
+        private LocalDate dueDate;
+    }
 }

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/dto/QuestResponseDTO.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/dto/QuestResponseDTO.java
@@ -88,6 +88,11 @@ public class QuestResponseDTO {
         private QuestType questType;
         private List<String> hashtags;
         private CompletionStatus completionStatus;
+
+        private LocalTime startTime;
+        private LocalTime endTime;
+        private LocalDate startDate;
+        private LocalDate dueDate;
     }
 
     // 메인 화면 조회 DTO
@@ -172,5 +177,28 @@ public class QuestResponseDTO {
         private Long partyId;
         private String partyName;
         private InvitationStatus invitationStatus;
+    }
+
+    // 퀘스트 수정 응답 DTO
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class QuestUpdateResponse {
+
+        private Long questId;
+        private String content;
+        private String message;
+    }
+
+    // 퀘스트 삭제 응답 DTO
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class QuestDeleteResponse {
+
+        private Long questId;
+        private String message;
     }
 }

--- a/src/main/java/ssuchaehwa/it_project/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/ssuchaehwa/it_project/global/error/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode{
     NO_SUCH_QUEST(HttpStatus.BAD_REQUEST, "QUEST_4001", "해당 퀘스트가 존재하지 않습니다."),
     QUEST_STATUS_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QUEST_4002", "퀘스트의 상태를 변경할 수 없습니다."),
     NO_PARTY_INVITATION(HttpStatus.BAD_REQUEST, "QUEST_4003", "초대 받은 파티가 존재하지 않습니다."),
+    QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "QUEST_404", "해당 퀘스트를 찾을 수 없습니다."),
+    QUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "QUEST_403", "퀘스트에 대한 접근 권한이 없습니다."),
 
     // token
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_401", "유효하지 않거나 만료된 refreshToken입니다."),

--- a/src/main/java/ssuchaehwa/it_project/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/ssuchaehwa/it_project/global/error/code/status/SuccessStatus.java
@@ -14,12 +14,16 @@ public enum SuccessStatus implements BaseCode {
     // quest
     QUEST_VIEW_SUCCESS(HttpStatus.OK, "QUEST_200", "퀘스트 리스트 조회를 완료했습니다"),
     QUEST_CREATED(HttpStatus.CREATED, "QUEST_201", "퀘스트가 성공적으로 생성되었습니다."),
+    QUEST_UPDATED(HttpStatus.OK, "QUEST_202", "퀘스트가 성공적으로 수정되었습니다."),
+    QUEST_DELETED(HttpStatus.OK, "QUEST_203", "퀘스트가 성공적으로 삭제되었습니다."),
+
     PARTY_CREATED(HttpStatus.CREATED, "PARTY_201", "파티가 성공적으로 생성되었습니다."),
     INVITE_FRIEND_CREATED(HttpStatus.CREATED, "INVITE_FRIEND_201", "친구 초대를 완료했습니다."),
     FRIEND_VIEW_SUCCESS(HttpStatus.OK, "FRIEND_200", "친구 리스트 조회를 완료했습니다."),
     QUEST_STATUS_CHANGE(HttpStatus.CREATED, "QUEST_201", "퀘스트의 상태가 성공적으로 변경되었습니다."),
     INVITE_PARTY_LIST_VIEW_SUCCESS(HttpStatus.OK, "PARTY_200", "초대 받은 파티 리스트 조회를 완료했습니다."),
     INVITE_PARTY_STATUS_CHANGE(HttpStatus.CREATED, "PARTY_201", "초대 받은 파티에 대한 응답을 완료했습니다."),
+
 
     // 뽀모도로
     POMODORO_COMPLETED(HttpStatus.CREATED, "POMODORO_201", "뽀모도로가 성공적으로 완료되었습니다."),


### PR DESCRIPTION
## 📌 PR 개요
- 개인 퀘스트 수정, 삭제 api 구현

## 🔧 작업 내용
- 퀘스트 조회 dto 수정
- 퀘스트 수정, 삭제 api 구현

## 📷 테스트
<img width="787" height="2079" alt="스크린샷 2025-08-05 오전 2 50 54" src="https://github.com/user-attachments/assets/27f99089-d0d1-4ec7-8fe2-75a2df337cbc" />

## ❗추가 내용
X