### PR TITLE
fix: 파티 조회 저장 로직 삭제

### DIFF
--- a/src/main/java/ssuchaehwa/it_project/domain/quest/application/QuestServiceImpl.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/application/QuestServiceImpl.java
@@ -751,34 +751,29 @@ public class QuestServiceImpl implements QuestService {
                 .toList();
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        distinct.forEach(p -> {
-            LocalDate pk = questAnalysisService.currentPeriodKeyFromAnchor(
-                    p.getQuestType().name(),
-                    p.getStartDate() != null ? p.getStartDate() : today,
-                    today
-            );
-            boolean exists = questOccurrenceRepository
-                    .existsByTemplateIdAndPeriodKeyAndQuestSource(p.getId(), pk, QuestSource.PARTY);
-            if (!exists) {
-                QuestOccurrence occ = QuestOccurrence.builder()
-                        .templateId(p.getId())
-                        .userId(userId)
-                        .questSource(QuestSource.PARTY)
-                        .questType(p.getQuestType().name())
-                        .periodKey(pk)
-                        .status("INCOMPLETE")
-                        .title(p.getQuestName())
-                        .expectedStartTime(p.getStartTime() == null ? null : p.getStartTime().toString())
-                        .expectedEndTime(p.getEndTime() == null ? null : p.getEndTime().toString())
-                        .build();
-                questOccurrenceRepository.save(occ);
-            }
-        });
 
         return distinct.stream()
-                .map(QuestConverter::toPartyListResponse) // DTO 변환
+                .map(p -> {
+                    LocalDate pk = questAnalysisService.currentPeriodKeyFromAnchor(
+                            p.getQuestType().name(),
+                            p.getStartDate() != null ? p.getStartDate() : today,
+                            today
+                    );
+
+                    Optional<QuestOccurrence> occurrence = questOccurrenceRepository
+                            .findByTemplateIdAndPeriodKeyAndQuestSource(p.getId(), pk, QuestSource.PARTY);
+
+                    // Occurrence 상태가 있으면 그대로, 없으면 INCOMPLETE
+                    CompletionStatus actualStatus = (occurrence.isPresent() &&
+                            "COMPLETED".equalsIgnoreCase(occurrence.get().getStatus()))
+                            ? CompletionStatus.COMPLETED
+                            : CompletionStatus.INCOMPLETE;
+
+                    return QuestConverter.toPartyListResponse(p, actualStatus);
+                })
                 .toList();
     }
+
 
     // 파티 수정
     @Transactional

--- a/src/main/java/ssuchaehwa/it_project/domain/quest/converter/QuestConverter.java
+++ b/src/main/java/ssuchaehwa/it_project/domain/quest/converter/QuestConverter.java
@@ -224,12 +224,12 @@ public class QuestConverter {
     }
 
     // 파티 조회
-    public static QuestResponseDTO.PartyListResponse toPartyListResponse(Party party) {
+    public static QuestResponseDTO.PartyListResponse toPartyListResponse(Party party, CompletionStatus actualStatus) {
         return QuestResponseDTO.PartyListResponse.builder()
                 .partyId(party.getId())
                 .partyTitle(party.getPartyTitle())
                 .questName(party.getQuestName())
-                .status(party.getCompletionStatus())
+                .status(actualStatus) // ✅ 엔티티 상태 대신 실제 occurrence 상태 반영
                 .startDate(party.getStartDate())
                 .dueDate(party.getDueDate())
                 .startTime(party.getStartTime())


### PR DESCRIPTION
## 📌 PR 개요
- 파티 조회에 있는 저장 로직 삭제
## 🔧 작업 내용
- GET 호출인데 상태 저장 로직이 존재해서 API 호출 시 500 에러 발생
## 📷 테스트

## ❗추가 내용
